### PR TITLE
Fix last chunk not being enqueued

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ class S3ReadableStream extends Readable {
 
     fillRequestQueue () {
         while (_.size(this.pendingRequests) < this.options.concurrency) {
-            if (this.currentPosition >= this.maxPosition) {
+            if (this.currentPosition > this.maxPosition) {
                 break;
             }
 


### PR DESCRIPTION
When the size of the file being streamed is multiple of the chunk size,
the `currentPosition` is equal to the `maxPosition` in the latest
iteration of the `fillRequestQueue` iteration. With the previous
implementation, this was making the method `fillRequestQueue` to exit.

In this situation, the last byte of the file, which is pointed by
`currentPosition` has not been processed yet and never gets enqueued.
Other parts of the code, hang waiting for the amount of data read to
match the total size of the file, but this never happens as the last
byte of the file never gets enqueued.

This change prevents this situation by not stopping enqueuing chunks
until the currentPosition is actually bigger than the `maxPosition`.