### PR TITLE
Add version support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,8 @@ class S3ReadableStream extends Readable {
 
         const params = {
             Bucket: this.s3Params.Bucket,
-            Key: this.s3Params.Key
+            Key: this.s3Params.Key,
+            VersionId: this.s3Params.VersionId,
         };
 
         return promiseRetry(this.retryOptions, (retry) => {


### PR DESCRIPTION
### Preamble
Hi folks, neat little utility,  it solved a problem for us related to time outs on s3 https://github.com/aws/aws-sdk-js/issues/2087

### What
The change adds the ability to request a particular version of an s3 object, if no version exists it will get the latest one, (as s3 defaults to latest).

### Why
Currently s3 readable stream does not support versioning